### PR TITLE
Detect tx replaced

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -125,7 +125,7 @@ endpoint.utils.processDeclinedTransaction = function (msg, res) {
             res = {};
         }
         res.errorCode = 'txDeclined';
-        res.error = 'Transaction was declined';
+        res.errorMessage = 'Transaction was declined';
         var func = 'var callback = ' + msg.options.error + ';' +
             '\ncallback(context.msg, context.res);';
         sys.utils.script.eval(func, {msg: msg, res: res});

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -90,10 +90,6 @@ endpoint.utils.processSubmittedTransaction = function (msg, res) {
                 sys.utils.script.eval(func, {msg: msg, res: res, receipt: receipt, events: events});
             },
             transactionRejected: function (response, data) {
-                sys.logs.error('TRANSACTION REJECTED ON ENPOINT');
-                sys.logs.error('ENDPOINT error.response: '+JSON.stringify(response));
-                sys.logs.error('ENDPOINT error.msg: '+JSON.stringify(data.msg));
-                sys.logs.error('ENDPOINT error.res: '+JSON.stringify(data.res));
                 var msg = data.msg;
                 var res = data.res;
                 res.errorCode = response.data.errorCode;
@@ -117,7 +113,6 @@ endpoint.utils.processSubmittedTransaction = function (msg, res) {
         if (msg.options.from) {
             txOptions.from = msg.options.from;
         }
-        sys.logs.error('from: '+txOptions.from);
         app.endpoints[msg.endpointName]._confirmTransaction(txOptions, callbackData, txCallbacks);
     }
 };
@@ -250,9 +245,6 @@ endpoint.utils.internalSendTransaction = function (options) {
                     return;
                 }
             }
-            sys.logs.error('rawTx.gas '+rawTx.gas);
-            sys.logs.error('rawTx.gasPrice '+rawTx.gasPrice);
-
             try {
                 rawTx.netId = options.netId;
                 signedRawTx = endpoint._signTransaction(rawTx);
@@ -439,7 +431,6 @@ endpoint.estimateTransaction = function (aliasOrAddress, fnName, params, fromAdd
  */
 endpoint.sendTransaction = function (aliasOrAddress, fnName, params, fromAddress, signMethod, options) {
     globalLock(fromAddress);
-    sys.logs.error('starting sending tx process');
     try {
         options = options || {};
         params = params || [];

--- a/src/main/java/io/slingr/endpoints/ethereum/EthereumEndpoint.java
+++ b/src/main/java/io/slingr/endpoints/ethereum/EthereumEndpoint.java
@@ -303,7 +303,9 @@ public class EthereumEndpoint extends HttpEndpoint {
         long timestamp = new Date().getTime();
         String txHash = body.string(Transaction.TX_HASH);
         confirmationTimeout = confirmationTimeout + timestamp;
-        transactionManager.registerTransaction(txHash, request.getFunctionId(), timestamp, confirmationTimeout, confirmationBlocks);
+        String nonce = body.string(Transaction.NONCE);
+        String from = body.string(Transaction.FROM);
+        transactionManager.registerTransaction(txHash, nonce, from, request.getFunctionId(), timestamp, confirmationTimeout, confirmationBlocks);
         Json resp = Json.map();
         resp.set("status", "ok");
         return resp;

--- a/src/main/java/io/slingr/endpoints/ethereum/Transaction.java
+++ b/src/main/java/io/slingr/endpoints/ethereum/Transaction.java
@@ -186,7 +186,6 @@ public class Transaction {
                 .set(TIMESTAMP, this.getTimestamp())
                 .set(TIMEOUT, this.getTimeout())
                 .set(RECEIPT, this.getReceipt())
-
                 .setIfNotEmpty(APP, this.getApp())
                 .setIfNotEmpty(ENV, this.getEnv());
     }

--- a/src/main/java/io/slingr/endpoints/ethereum/Transaction.java
+++ b/src/main/java/io/slingr/endpoints/ethereum/Transaction.java
@@ -14,6 +14,8 @@ public class Transaction {
     public final static String STATUS = "status";
     public final static String TIMESTAMP = "timestamp";
     public final static String TIMEOUT = "timeout";
+    public final static String NONCE = "nonce";
+    public final static String FROM = "from";
     public final static String CONFIRMATION_BLOCKS = "confirmationBlocks";
     public final static String RECEIPT = "receipt";
     public static final String STATUS_PENDING = "pending";
@@ -21,6 +23,7 @@ public class Transaction {
     public static final String STATUS_REMOVED = "removed";
     public static final String STATUS_SENT = "sent";
     public static final String STATUS_TIMEOUT = "timeout";
+    public static final String STATUS_REPLACED = "replaced";
     public static final String APP = "app";
     public static final String ENV = "env";
 
@@ -33,12 +36,17 @@ public class Transaction {
     private long timeout;
     private long confirmationBlocks;
     private String status = STATUS_PENDING;
+
+    private String nonce;
+    private String from;
     private String app;
     private String env;
     private Json receipt;
 
-    public Transaction(String txHash, String functionId, long timestamp, long timeout, long confirmationBlocks) {
+    public Transaction(String txHash, String nonce, String from, String functionId, long timestamp, long timeout, long confirmationBlocks) {
         this.txHash = txHash;
+        this.nonce = nonce;
+        this.from = from;
         this.functionId = functionId;
         this.timestamp = timestamp;
         this.timeout = timeout;
@@ -132,6 +140,22 @@ public class Transaction {
         this.receipt = receipt;
     }
 
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
     public String getApp() {
         return app;
     }
@@ -152,6 +176,8 @@ public class Transaction {
         return Json.map()
                 .set(ID, this.getId())
                 .set(TX_HASH, this.getTxHash())
+                .set(NONCE, this.getNonce())
+                .set(FROM, this.getFrom())
                 .set(BLOCK_HASH, this.getBlockHash())
                 .set(BLOCK_NUMBER, this.getBlockNumber())
                 .set(FUNCTION_ID, this.getFunctionId())
@@ -160,6 +186,7 @@ public class Transaction {
                 .set(TIMESTAMP, this.getTimestamp())
                 .set(TIMEOUT, this.getTimeout())
                 .set(RECEIPT, this.getReceipt())
+
                 .setIfNotEmpty(APP, this.getApp())
                 .setIfNotEmpty(ENV, this.getEnv());
     }
@@ -167,6 +194,8 @@ public class Transaction {
     public void fromJson(Json tx) {
         this.setId(tx.string(ID));
         this.setTxHash(tx.string(TX_HASH));
+        this.setNonce(tx.string(NONCE));
+        this.setFrom(tx.string(FROM));
         this.setBlockHash(tx.string(BLOCK_HASH));
         this.setBlockNumber(tx.longInteger(BLOCK_NUMBER));
         this.setFunctionId(tx.string(FUNCTION_ID));

--- a/src/main/java/io/slingr/endpoints/ethereum/TransactionManager.java
+++ b/src/main/java/io/slingr/endpoints/ethereum/TransactionManager.java
@@ -154,7 +154,6 @@ public class TransactionManager {
                             transactionsDs.update(txReplaced.toJson());
                             txsToRemove.add(txHashReplaced);
                         }
-                        ;
                     }
                 } else if (Transaction.STATUS_PENDING.equals(tx.getStatus())) {
                     // check if the transaction has timed out

--- a/src/main/java/io/slingr/endpoints/ethereum/TransactionManager.java
+++ b/src/main/java/io/slingr/endpoints/ethereum/TransactionManager.java
@@ -112,7 +112,7 @@ public class TransactionManager {
                 if (pendingTransactions.containsKey(txHash)) {
                     Transaction pendingTransaction = pendingTransactions.get(txHash);
                     pendingTransaction.setBlockHash(block.getHash());
-                    pendingTransaction.setBlockNumber(block.getNumber());git log
+                    pendingTransaction.setBlockNumber(block.getNumber());
                     pendingTransaction.setStatus(Transaction.STATUS_CONFIRMED);
                     transactionsDs.update(pendingTransaction.toJson());
                 }
@@ -139,7 +139,7 @@ public class TransactionManager {
                     for (String txHashReplaced : pendingTransactions.keySet()) {
                         Transaction txReplaced = pendingTransactions.get(txHashReplaced);
                         if (tx.getFrom().equals(txReplaced.getFrom()) && !txHashReplaced.equals(txHash) && tx.getNonce().equals(txReplaced.getNonce())) {
-                            // check if there was a tx with the same nonce that was replaced
+                            // check if there is a tx with the same nonce that was replaced
                             Json res = Json.map();
                             res.set("receipt", txReplaced.getReceipt());
                             res.set("errorCode", "replaced");
@@ -149,7 +149,7 @@ public class TransactionManager {
                             transactionsDs.update(txReplaced.toJson());
                             txsToRemove.add(txHashReplaced);
                         } else if (tx.getFrom().equals(txReplaced.getFrom()) && Integer.decode(txReplaced.getNonce()) < (Integer.decode(tx.getNonce()))) {
-                            // check if there was a tx with a lower nonce that will never be mined
+                            // check if there is a tx with a lower nonce that will never be mined
                             txReplaced.setStatus(Transaction.STATUS_REMOVED);
                             transactionsDs.update(txReplaced.toJson());
                             txsToRemove.add(txHashReplaced);


### PR DESCRIPTION
- TX have 2 new attributes: From address and the nonce that will be used to detect if a tx has been replaced
- When a tx is confirmed the app will check if there is a pending tx with the same nonce as the confirmed one. And will trigger the error callback of the replaced tx.
- There is a fix on how the "res" sent to the app is built. Now replaced and timeout error codes and messages will be properly sent to the app. 