### PR TITLE
New nonce calculation method

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -759,10 +759,8 @@ function globalUnlock(key) {
 }
 
 function getNonce(address, nonceCalculationMethod) {
-    sys.logs.error('GET nonceCalculationMethod: '+nonceCalculationMethod);
     var nonce = sys.storage.get("ethereum-endpoint-"+address+'-nonce');
     if (nonce && nonceCalculationMethod == 'calculationInEndpoint') {
-        sys.logs.error('Get nonce calculated in endpoint');
         return nonce;
     } else {
         return endpoint.eth.transactionCount(address, 'pending');
@@ -770,10 +768,8 @@ function getNonce(address, nonceCalculationMethod) {
 }
 
 function setNextNonce(address, nonce, nonceCalculationMethod) {
-    sys.logs.error('SET nonceCalculationMethod: '+nonceCalculationMethod);
     if (nonce && nonceCalculationMethod == 'calculationInEndpoint') {
         var nextNonce = parseInt(nonce) + 1;
-        sys.logs.error('Calculate next Nonce in endpoint: '+nextNonce);
         sys.storage.put("ethereum-endpoint-" + address + '-nonce', '0x' + nextNonce.toString(16), {ttl: 2 * 60 * 1000});
     }
 }


### PR DESCRIPTION
In this new method:
- We can let the endpoint to calculate the nonce if we send an option parameter . If not, the default option will call the method getTransactionCount().
- The method will increment the nonce when a tx is submitted. And the following tx will use that nonce.
- If there is an error when submitting the tx, the nonce will not be incremented and the following tx will use the corresponding nonce.
Extra: there is a minor fix on how the res parameter on transactions rejected are built.